### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,12 @@ language: php
 php:
   - 5.6
   - 7.1
+  - 7.2
+  - nightly
 
+matrix:
+  allow_failures:
+    - php: nightly
 script:
   - composer install --prefer-dist --no-interaction
   - mkdir -p build/logs

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         }
     },
     "require-dev": {
-        "satooshi/php-coveralls": "dev-master",
-        "phpunit/phpunit": "5.7.5"
+        "satooshi/php-coveralls": "^1.1",
+        "phpunit/phpunit": "^5.7 || ^6.5"
     }
 }

--- a/tests/Ajaxray/PHPWatermark/Tests/CommandBuilders/ImageCommandBuilderTest.php
+++ b/tests/Ajaxray/PHPWatermark/Tests/CommandBuilders/ImageCommandBuilderTest.php
@@ -11,8 +11,9 @@ namespace Ajaxray\PHPWatermark\Tests\CommandBuilders;
 
 use Ajaxray\PHPWatermark\CommandBuilders\ImageCommandBuilder;
 use Ajaxray\PHPWatermark\Watermark;
+use PHPUnit\Framework\TestCase;
 
-class ImageCommandBuilderTest extends \PHPUnit_Framework_TestCase
+class ImageCommandBuilderTest extends TestCase
 {
     protected $options = [
         'position' => 'Center',

--- a/tests/Ajaxray/PHPWatermark/Tests/CommandBuilders/PDFCommandBuilderTest.php
+++ b/tests/Ajaxray/PHPWatermark/Tests/CommandBuilders/PDFCommandBuilderTest.php
@@ -11,8 +11,9 @@ namespace Ajaxray\PHPWatermark\Tests\CommandBuilders;
 
 use Ajaxray\PHPWatermark\CommandBuilders\PDFCommandBuilder;
 use Ajaxray\PHPWatermark\Watermark;
+use PHPUnit\Framework\TestCase;
 
-class PDFCommandBuilderTest extends \PHPUnit_Framework_TestCase
+class PDFCommandBuilderTest extends TestCase
 {
     protected $options = [
         'position' => 'Center',

--- a/tests/Ajaxray/PHPWatermark/Tests/WatermarkTest.php
+++ b/tests/Ajaxray/PHPWatermark/Tests/WatermarkTest.php
@@ -11,8 +11,9 @@ use Ajaxray\PHPWatermark\CommandBuilders\ImageCommandBuilder;
 use Ajaxray\PHPWatermark\CommandBuilders\PDFCommandBuilder;
 use Ajaxray\PHPWatermark\Watermark;
 use Ajaxray\TestUtils\NonPublicAccess;
+use PHPUnit\Framework\TestCase;
 
-class WatermarkTest extends \PHPUnit_Framework_TestCase
+class WatermarkTest extends TestCase
 {
     use NonPublicAccess;
 
@@ -211,6 +212,56 @@ class WatermarkTest extends \PHPUnit_Framework_TestCase
 
         $this->assertContains('composit', $command);
         $this->assertContains('path/to/logo.png', $command);
+    }
+
+    public function testSetPositionOnPositionList()
+    {
+        $watermark = new Watermark('path/to/file.jpg');
+        $setPosition = $watermark->setPosition(Watermark::POSITION_CENTER);
+        $options = $this->invokeProperty($watermark, 'options');
+
+        $this->assertInstanceOf(Watermark::class, $setPosition);
+        $this->assertContains(Watermark::POSITION_CENTER, $options);
+    }
+
+    public function testSetStyle()
+    {
+        $watermark = new Watermark('path/to/file.jpg');
+        $setStyle = $watermark->setStyle(Watermark::STYLE_IMG_COLORLESS);
+        $options = $this->invokeProperty($watermark, 'options');
+
+        $this->assertInstanceOf(Watermark::class, $setStyle);
+        $this->assertContains(Watermark::STYLE_IMG_COLORLESS, $options);
+    }
+
+    public function testSetTileSize()
+    {
+        $watermark = new Watermark('path/to/file.jpg');
+        $setStyle = $watermark->setTileSize(200, 150);
+        $options = $this->invokeProperty($watermark, 'options');
+
+        $this->assertInstanceOf(Watermark::class, $setStyle);
+        $this->assertContains([200, 150], $options);
+    }
+
+    public function testSetFont()
+    {
+        $watermark = new Watermark('path/to/file.jpg');
+        $setFont = $watermark->setFont('Arial');
+        $options = $this->invokeProperty($watermark, 'options');
+
+        $this->assertInstanceOf(Watermark::class, $setFont);
+        $this->assertContains('Arial', $options);
+    }
+
+    public function testSetFontSize()
+    {
+        $watermark = new Watermark('path/to/file.jpg');
+        $setFontSize = $watermark->setFontSize(20);
+        $options = $this->invokeProperty($watermark, 'options');
+
+        $this->assertInstanceOf(Watermark::class, $setFontSize);
+        $this->assertContains(20, $options);
     }
 
 }


### PR DESCRIPTION
# Changed log 
- Set multiple PHPUnit versions to support different PHP versions.
- Set the nightly test and accept this can be failed in Travis CI build.
- Add the ```php-7.2``` test in Travis CI build.
- Use the class-based PHPUnit namespace to support the stable PHPUnit version.
- Add more tests.