### PR TITLE
Enable checking of imagemagick installation

### DIFF
--- a/src/Ajaxray/PHPWatermark/CommandBuilders/AbstractCommandBuilder.php
+++ b/src/Ajaxray/PHPWatermark/CommandBuilders/AbstractCommandBuilder.php
@@ -9,6 +9,8 @@
 namespace Ajaxray\PHPWatermark\CommandBuilders;
 
 
+use Ajaxray\PHPWatermark\Requirements\RequirementsChecker;
+
 abstract class AbstractCommandBuilder
 {
     protected $options;
@@ -26,6 +28,8 @@ abstract class AbstractCommandBuilder
     public function __construct($source)
     {
         $this->source = $source;
+
+        (new RequirementsChecker())->checkImagemagickInstallation();
     }
 
 

--- a/src/Ajaxray/PHPWatermark/Requirements/RequirementsChecker.php
+++ b/src/Ajaxray/PHPWatermark/Requirements/RequirementsChecker.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Criado por Maizer Aly de O. Gomes para php-watermark.
+ * Email: maizer.gomes@gmail.com / maizer.gomes@ekutivasolutions / maizer.gomes@outlook.com
+ * Usuário: maizerg
+ * Data: 7/20/18
+ * Hora: 12:01 PM
+ */
+
+namespace Ajaxray\PHPWatermark\Requirements;
+
+class RequirementsChecker
+{
+
+    public function checkImagemagickInstallation()
+    {
+        exec("convert -version", $out, $rcode);
+
+        if ($rcode) {
+            throw new \BadFunctionCallException("ImageMagick not found in this system.");
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
Hi,
First I would like to thank you for this package, It works great.

Had a problem when my application went **live**, where I didn't notice that **ImageMagick** wasn't installed on my production server and **PHP-Watermark** would **fail silently** and only after some time I noticed the watermarked files weren't being generated.

I believe it should first check if the dependency on **ImageMagick** is satisfied first before executing any logic thus avoiding passing false positives to the rest of the application.

I added a little check on the constructor of the abstract class where it tries to execute the convert command and throws an error if the status code is different from 0.